### PR TITLE
Show log area over the content to improve usability

### DIFF
--- a/www/res/style.css
+++ b/www/res/style.css
@@ -31,12 +31,16 @@ a {
 	color: #CCC;
 	border: 0;
 	font-size: 0.3cm;
-	overflow: hidden;
+	overflow: hidden auto;
 	white-space: pre-wrap;
 	margin: 0;
+	max-height: 50vh;
 }
 #logfilearea{
-	position:relative;
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+	z-index: 100;
 }
 #logfileactivate {
 	text-align: center;
@@ -101,6 +105,10 @@ select > option[disabled] {
 	scrollbar-width: none;
 }
 
+
+#lastevents {
+	margin-bottom: 0.75cm;
+}
 
 #lastevents table {
 		width: 100%;
@@ -472,14 +480,6 @@ x-trbgr.hdr {
 	content: "pos: ";
 	vertical-align: sub;
 	font-size: 0.7em;
-}
-
-#lastevents {
-}
-
-#lastevents::-webkit-scrollbar{
-	width: 0;	
-	
 }
 
 .summary {


### PR DESCRIPTION
- Version string and log button has fixed position at the bottom of the screen.
- There is margin for #lastevents to make room for the version string and log button when scrolled to the bottom.
- Log expands over the content so you don't need to scroll down to see it.
- Log area occupies max. 50 % of the viewport height in order to see both content and log and to work correctly on small screens.